### PR TITLE
feat(chrome): change default debug port from 9222 to 9223

### DIFF
--- a/quora_scraper/parallel_answer_processor.py
+++ b/quora_scraper/parallel_answer_processor.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 class ParallelChromeManager(ChromeDriverManager):
     """Chrome manager for parallel processing with specific port"""
 
-    def __init__(self, debug_port: int = 9222):
+    def __init__(self, debug_port: int = 9223):
         super().__init__()
         self.debug_port = debug_port
         self.driver = None
@@ -377,7 +377,7 @@ class ParallelAnswerProcessor:
 
     def __init__(self, num_workers: int = 3):
         self.num_workers = min(num_workers, 5)  # Max 5 workers
-        self.base_debug_port = 9222
+        self.base_debug_port = 9223
         self.failed_urls = []
         self.setup_logging()
 

--- a/start_chrome_debug.py
+++ b/start_chrome_debug.py
@@ -13,7 +13,7 @@ import os
 
 def start_chrome_with_debugging():
     """Start Chrome with remote debugging enabled"""
-    debug_port = 9222
+    debug_port = 9223
     
     # Check if Chrome is already running with debugging
     try:

--- a/start_parallel_chrome.py
+++ b/start_parallel_chrome.py
@@ -84,7 +84,7 @@ def start_chrome_instance(port, new_window=True):
         return None
 
 
-def stop_all_chrome_instances(base_port=9222, num_instances=5):
+def stop_all_chrome_instances(base_port=9223, num_instances=5):
     """Stop all Chrome instances by closing their debug connections"""
     print("\nStopping Chrome instances...")
     stopped = 0
@@ -142,8 +142,8 @@ Examples:
     parser.add_argument(
         '--base-port',
         type=int,
-        default=9222,
-        help='Base port for Chrome debugging (default: 9222)'
+        default=9223,
+        help='Base port for Chrome debugging (default: 9223)'
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
Update base debug port across all Chrome management components to avoid conflicts with existing Chrome instances. Also optimize scroll wait strategy in profile spider with adaptive timing based on content loading status.